### PR TITLE
PLAT-971 - Added committag and commitmessage to S3 Metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude: .*/keys/.*|
-              (?x)(
-                     ^package-lock.json$/|
-                     ^Pipfile/|
-                     ^pyproject.toml
-              )
+        # exclude: .*/keys/.*|
+        #       (?x)(
+        #              ^package-lock.json$/|
+        #              ^Pipfile/|
+        #              ^pyproject.toml
+        #       )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude:  .*/keys/.*|
+        exclude: .*/keys/.*|
               (
                      ^package-lock.json$|
                      ^Pipfile|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        # exclude: .*/keys/.*|
-        #       (?x)(
-        #              ^package-lock.json$/|
-        #              ^Pipfile/|
-        #              ^pyproject.toml
-        #       )
+        exclude:  .*/keys/.*|
+              (
+                     ^package-lock.json$|
+                     ^Pipfile|
+                     ^pyproject.toml
+              )

--- a/README.md
+++ b/README.md
@@ -53,3 +53,14 @@ NOTE: Until v3 is released, you will need to point both v1 and v2 to the latest 
 ### Breaking changes
 
 Release a new major version as normal following semantic versioning.
+
+### Preparing a release
+
+When working on a PR branch, create a release with the target version, but append -beta to the tag name.
+
+e.g.
+
+`git tag v3.1-beta`
+
+You can then navigate to the release page, and create a pre-release to validate that the tag is working as expected.
+After you've merged the PR, then apply the correct tag for your release.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This is an action that allows you to upload a built SAM application to S3 using 
 
 The action packages, signs the Lambda functions, and uploads the application to the specified S3 bucket.
 
+It adds the following metadata to the S3 object:
+
+- committag - The tag of the git commit (if present), this falls back to a shortened commit has.
+- repository - The git repository where the file was loaded from
+- commitmessage - The first 50 characters of the git commit message, trimmed to the following regex: `tr -dc '[:alnum:]- '`
+- commitsha - The full git commitsha of the git commit.
+
 ## Action Inputs
 
 | Input                | Required | Description                                                                     | Example              |

--- a/action.yaml
+++ b/action.yaml
@@ -29,5 +29,6 @@ runs:
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
         SIGNING_PROFILE: ${{ inputs.signing-profile-name }}
         TEMPLATE_FILE: ${{ inputs.template-file }}
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: ${{ github.action_path }}/scripts/upload.sh
       shell: bash

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -19,6 +19,7 @@ else
   sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles "${PROFILES[*]}"
 fi
 
+# This only gets set if there is a tag on the current commit.
 GIT_TAG=`git describe --tags --exact-match`
 
 echo "Writing Lambda provenance"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -33,4 +33,4 @@ echo "Zipping the CloudFormation template"
 zip template.zip cf-template.yaml
 
 echo "Uploading zipped CloudFormation artifact to S3"
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,author=,committag="
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -24,10 +24,10 @@ GIT_TAG=$(git describe --tags --first-parent --always)
 
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,committag=$GIT_TAG"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
 echo "Writing Lambda Layer provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,committag=$GIT_TAG"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
 
 echo "Zipping the CloudFormation template"
 zip template.zip cf-template.yaml

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -19,7 +19,7 @@ else
   sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles "${PROFILES[*]}"
 fi
 
-GIT_TAG=`git describe --tags`
+GIT_TAG=`git describe --tags --exact-match`
 
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -19,15 +19,17 @@ else
   sam package --s3-bucket="$ARTIFACT_BUCKET" --output-template-file=cf-template.yaml --signing-profiles "${PROFILES[*]}"
 fi
 
+GIT_TAG=`git describe --tags`
+
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,committag=$GIT_TAG"
 echo "Writing Lambda Layer provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,committag=$GIT_TAG"
 
 echo "Zipping the CloudFormation template"
 zip template.zip cf-template.yaml
 
 echo "Uploading zipped CloudFormation artifact to S3"
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,author=,committag="

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # This only gets set if there is a tag on the current commit.
-GIT_TAG=$(git describe --tags --exact-match||true)
+GIT_TAG=$(git describe --tags --first-parent --always)
 
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -24,13 +24,13 @@ GIT_TAG=$(git describe --tags --first-parent --always)
 
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MESSAGE"
 echo "Writing Lambda Layer provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MESSAGE"
 
 echo "Zipping the CloudFormation template"
 zip template.zip cf-template.yaml
 
 echo "Uploading zipped CloudFormation artifact to S3"
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,committag=$GIT_TAG"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # This only gets set if there is a tag on the current commit.
-GIT_TAG=`git describe --tags --exact-match`
+GIT_TAG=$(git describe --tags --exact-match||true)
 
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -24,13 +24,13 @@ GIT_TAG=$(git describe --tags --first-parent --always)
 
 echo "Writing Lambda provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MESSAGE"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
 echo "Writing Lambda Layer provenance"
 yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MESSAGE"
+    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"
 
 echo "Zipping the CloudFormation template"
 zip template.zip cf-template.yaml
 
 echo "Uploading zipped CloudFormation artifact to S3"
-aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,commitmessage=$COMMIT_MESSAGE,committag=$GIT_TAG"
+aws s3 cp template.zip "s3://$ARTIFACT_BUCKET/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG"


### PR DESCRIPTION
For production tracking, collecting the COMMIT_MESSAGE and GIT_TAG of the commits to be able to annotate production deploys with more information.